### PR TITLE
Use nodemon example file instead of checking in nodemon.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 
-people.json
+nodemon.json
 data.js
 notes.md
 aws.json

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -15,19 +15,17 @@ This project requires you have a few things installed and running:
 - [Gulp](https://www.npmjs.com/package/gulp) 3.9 - our build system
 - [Nodemon](https://www.npmjs.com/package/nodemon) 1.x - for running node in development
 
-You'll also need some of your own keys for various services we use:
-
-> TODO - Try to remove these deps if we can for development!
-
-- AWS
-- Twitter
-- Mandrill
-
 ## Steps
 
 This could definitely be scripted up a bit better, but for now. This works ;)
 
-First we ensure Mongo and Redis are running w/ default settings.
+First, copy the [`nodemon.json.example`](https://github.com/timezoneio/timezoneio/blob/master/nodemon.json.example)
+file into your own `nodemon.json` file and add your own keys for AWS and Twitter.
+> TODO - Add more guidance on how to get your own keys or remove the need for
+these at all
+
+
+Before running the app we ensure Mongo and Redis are running w/ default settings.
 
 ```shell
 $ mongod

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,8 +1,0 @@
-{
-  "env": {
-    "NODE_ENV": "development",
-    "S3_BUCKET": "timezone-uploads-dev"
-  },
-  "ignore": ["public/**/*.js"],
-  "ext": "js json hjs jsx"
-}

--- a/nodemon.json.example
+++ b/nodemon.json.example
@@ -1,0 +1,18 @@
+{
+  "env": {
+    "NODE_ENV": "development",
+    "S3_BUCKET": "timezone-uploads-dev",
+
+    "EMAIL_HASH_SALT": "ABC",
+    "PASSWORD_RESET_TOKEN_SALT": "DEF",
+    "INVITE_SALT": "GHI",
+
+    "AWS_ACCESS_KEY": "<your key>",
+    "AWS_SECRET_KEY": "<your secret>",
+
+    "TWITTER_KEY": "<your key>",
+    "TWITTER_SECRET": "<your secret>"
+  },
+  "ignore": ["public/**/*.js"],
+  "ext": "js json hjs jsx"
+}


### PR DESCRIPTION
### Purpose
For easier local setup of keys and secrets, remove nodemon.json from the repo so users can create their own from the `nodemon.json.example file`.