### PR TITLE
Improve horizontal view for teams on small screens

### DIFF
--- a/app/components/timezoneList.jsx
+++ b/app/components/timezoneList.jsx
@@ -53,13 +53,15 @@ class TimezoneList extends React.Component {
 
     return (
       <div className={containerClasses}>
-        {this.props.timezones.map(function(timezone) {
-          return <Timezone key={timezone.tz}
-                           timezone={timezone}
-                           time={this.props.time}
-                           timeFormat={timeFormat}
-                           activeFilter={this.props.activeFilter} />
-        }.bind(this))}
+        <div className="timezone-wrapper">
+          {this.props.timezones.map(function(timezone) {
+            return <Timezone key={timezone.tz}
+                             timezone={timezone}
+                             time={this.props.time}
+                             timeFormat={timeFormat}
+                             activeFilter={this.props.activeFilter} />
+          }.bind(this))}
+        </div>
         { this.props.showStats &&
           <div className="team-stats"><em>{stats}</em></div>
         }

--- a/app/components/timezoneList.jsx
+++ b/app/components/timezoneList.jsx
@@ -1,3 +1,5 @@
+'use strict';
+
 var React    = require('react');
 var classNames = require('classnames');
 var Timezone = require('./timezone.jsx');
@@ -15,11 +17,9 @@ var count = function(metric, people) {
   return items.length;
 };
 
-module.exports = React.createClass({
+class TimezoneList extends React.Component {
 
-  displayName: 'TimezoneList',
-
-  getStats: function(people) {
+  getStats(people) {
 
     // Note the homepage doesn't provide people, only timezones
     if (!people || !Array.isArray(people)) return;
@@ -29,15 +29,15 @@ module.exports = React.createClass({
     var numTimezones = this.props.timezones.length;
 
     return `${numPeople} people in ${numCities} cities across ${numTimezones} timezones`;
-  },
+  }
 
-  getColumnNumber: function(timezones) {
+  getColumnNumber(timezones) {
     return timezones.reduce(function(cols, timezone) {
       return cols + Math.ceil(timezone.people.length / PEOPLE_PER_COL);
     }, 0);
-  },
+  }
 
-  render: function() {
+  render() {
 
     var timeFormat = this.props.timeFormat || 12;
 
@@ -67,4 +67,6 @@ module.exports = React.createClass({
     );
   }
 
-});
+}
+
+module.exports = TimezoneList;

--- a/app/components/timezoneList.jsx
+++ b/app/components/timezoneList.jsx
@@ -2,7 +2,7 @@
 
 var React    = require('react');
 var classNames = require('classnames');
-var Timezone = require('./timezone.jsx');
+var Timezone = require('./timezone');
 
 const PEOPLE_PER_COL = 8;
 
@@ -55,11 +55,15 @@ class TimezoneList extends React.Component {
       <div className={containerClasses}>
         <div className="timezone-wrapper">
           {this.props.timezones.map(function(timezone) {
-            return <Timezone key={timezone.tz}
-                             timezone={timezone}
-                             time={this.props.time}
-                             timeFormat={timeFormat}
-                             activeFilter={this.props.activeFilter} />
+            return (
+              <Timezone
+                key={timezone.tz}
+                timezone={timezone}
+                time={this.props.time}
+                timeFormat={timeFormat}
+                activeFilter={this.props.activeFilter}
+              />
+            );
           }.bind(this))}
         </div>
         { this.props.showStats &&

--- a/app/views/signup.jsx
+++ b/app/views/signup.jsx
@@ -78,6 +78,6 @@ class Signup extends React.Component {
       </div>
     );
   }
-};
+}
 
 module.exports = Signup;

--- a/assets/stylesheets/pages/team.styl
+++ b/assets/stylesheets/pages/team.styl
@@ -131,13 +131,14 @@ $toolbarItemHeight = 32px;
   position relative
   z-index: 5
   display: flex
-  height: 100%;
+  height: 100%
+  max-width: 100%
   justify-content: center
-  flex-grow: 1 // this grows, the sidebar is a fixed width
+  flex-grow: 1 // this grows
+  overflow-y: scroll
 
 // For teams larger than 10 colums
 .timezone-list-wide
-  justify-content: flex-start // for wide teams left justify the columns
 
   .timezone
     padding-left: 0.8em
@@ -158,6 +159,8 @@ $toolbarItemHeight = 32px;
     width: 54px
     line-height: 54px // for placeholder
 
+
+
 .team-stats
   position absolute
   bottom 0.5em
@@ -165,6 +168,10 @@ $toolbarItemHeight = 32px;
   right 0
   text-align center
   color $mutedColor
+
+.timezone-wrapper
+  display: flex
+  max-width: 100%
 
 .timezone
   padding: 1em
@@ -513,15 +520,13 @@ input[type="text"].manage-team--invite-url
 
   .app-sidebar--format-select
     display: none
-    // margin-right: 0.8em
-    // white-space: nowrap
 
-  // .app-sidebar--admin
-
-  .timezone-list
-    margin-top: 6em
+  .timezone-list,
+  .timezone-wrapper
     justify-content: flex-start
     flex-direction: column-reverse
+
+
 
   .team-stats
     position relative

--- a/rev-manifest.json
+++ b/rev-manifest.json
@@ -5,8 +5,8 @@
   "js/bundles/contact.js": "js/bundles/contact-efabb0ddaf.js.gz",
   "js/bundles/createTeam.js": "js/bundles/createTeam-999e6581d9.js.gz",
   "js/bundles/getStarted.js": "js/bundles/getStarted-ecf171a6f4.js.gz",
-  "js/bundles/homepage.js": "js/bundles/homepage-26ecd18359.js.gz",
+  "js/bundles/homepage.js": "js/bundles/homepage-387ffb4a4e.js.gz",
   "js/bundles/person.js": "js/bundles/person-d16d686f97.js.gz",
-  "js/bundles/team.js": "js/bundles/team-6e8827ab44.js.gz",
-  "stylesheets/index.css": "stylesheets/index-16db61efb2.css.gz"
+  "js/bundles/team.js": "js/bundles/team-a501ee831e.js.gz",
+  "stylesheets/index.css": "stylesheets/index-df889411b8.css.gz"
 }


### PR DESCRIPTION
### Purpose
The leftmost column would be cut off when the screen was narrower than the width of the team, creating an entire timezone out of view. Using a wrapper div and some flexbox changes this fixes that.