### PR TITLE
Add team members without inviting

### DIFF
--- a/app/components/editPerson.jsx
+++ b/app/components/editPerson.jsx
@@ -44,7 +44,7 @@ var EditPerson = React.createClass({
   },
 
   getFileName: function() {
-    return this.state.userId || this.state.emailHash;
+    return this.state.userId || this.state.emailHash || `${this.props.teamId}_${Date.now()}`;
   },
 
   handleChange: function(name, value) {
@@ -77,6 +77,10 @@ var EditPerson = React.createClass({
     var data = extend(this.state, { teamId: this.props.teamId });
     delete data.error;
     delete data.saveButtonText;
+
+    if (!data.email) {
+      data.stub = true;
+    }
 
     var createOrUpdateUser = this.state.isNewUser ?
                               ActionCreators.addNewTeamMember(data) :
@@ -147,6 +151,14 @@ var EditPerson = React.createClass({
   },
 
   handleCheckUserEmail: function() {
+
+    // Allow empty email
+    if (!this.state.email || !this.state.email.length) {
+      return this.setState({
+        isNewUser: true,
+        isExistingUser: false
+      });
+    }
 
     if (!isValidEmail(this.state.email))
       return this.setState({ error: 'Please enter a valid email ;)' });

--- a/app/controllers/api.js
+++ b/app/controllers/api.js
@@ -71,8 +71,8 @@ api.userCreate = function(req, res, next) {
 
   var userData = req.body;
 
-  // could be DRYer
-  if (!userData.email)
+  // Stub users don't have an email
+  if (!userData.email && !userData.stub)
     return handleError(res, 'An email is required');
   if (!userData.name)
     return handleError(res, 'An name is required');
@@ -81,12 +81,18 @@ api.userCreate = function(req, res, next) {
   if (!userData.tz)
     return handleError(res, 'An timezone is required');
 
-  UserModel.findOneByEmail(userData.email, function(err, user) {
+  if (userData.email) {
+    userData.email = userData.email.toLowerCase();
+  } else if (userData.stub) {
+    delete userData.email;
+  }
+
+  var findUser = userData.email ? UserModel.findOneByEmail(userData.email) : Promise.resolve();
+
+  findUser.then(function(user) {
 
     // NOTE - in the future we should do a search before creating user
     if (user) return handleError(res, 'That user already exists!');
-
-    userData.email = userData.email.toLowerCase();
 
     var validData = {};
     for (var key in userData) {
@@ -104,12 +110,14 @@ api.userCreate = function(req, res, next) {
         newUser.save(function(err) {
           if (err) return handleError(res, 'Failed to save: ' + err);
 
-          sendEmail('invite', newUser.email, {
-            inviteUrl: req.team.getInviteUrl(newUser),
-            adminName: req.user.name,
-            name: newUser.name || 'there', // Hi <there>!,
-            teamName: req.team.name
-          });
+          if (newUser.email) {
+            sendEmail('invite', newUser.email, {
+              inviteUrl: req.team.getInviteUrl(newUser),
+              adminName: req.user.name,
+              name: newUser.name || 'there', // Hi <there>!,
+              teamName: req.team.name
+            });
+          }
 
           res.json(newUser);
         });
@@ -239,7 +247,7 @@ api.teamDelete = function(req, res) {
     }, createErrorHandler());
 };
 
-api.teamAddMember = function(req, res, next) {
+api.teamAddMember = function(req, res) {
   var team = req.team;
   var userId = req.body.userId;
 

--- a/app/models/team.js
+++ b/app/models/team.js
@@ -123,7 +123,7 @@ teamSchema.methods = {
       .find({ team: this._id })
       .populate('user')
       .then(function(teamMembers) {
-        return teamMembers.map( (tm) => tm.user );
+        return teamMembers.map((tm) => tm.user).filter((user) => !!user);
       });
   },
 

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -13,6 +13,7 @@ const ENV = require('../../env');
 var userSchema = new Schema({
   username: { type: String, default: '' },
   name: { type: String, default: '' },
+  stub: { type: Boolean, default: false },
   email: { type: String, default: '' },
   provider: { type: String, default: '' },
   hashedPassword: { type: String, default: '' },
@@ -246,12 +247,15 @@ userSchema.methods = {
    */
 
   skipValidation: function() {
-    return false;
+    return this.stub === true;
     // return ~oAuthTypes.indexOf(this.provider);
   },
 
   // Used for team invite emails and verifying user's identity
   getEmailHash: function() {
+    if (!this.email) {
+      return null;
+    }
     return crypto.createHash('md5')
                  .update(ENV.EMAIL_HASH_SALT + this.email)
                  .digest('hex')
@@ -367,6 +371,7 @@ userSchema.statics = {
   WRITABLE_FIELDS: WRITABLE_FIELDS,
 
   ADMIN_WRITABLE_FIELDS: WRITABLE_FIELDS.concat([
+    'stub',
     'email'
   ]),
 


### PR DESCRIPTION
### Purpose

To build out the spec in #9.
### Checklist
- [x] Remove requirement for email in user model (a "stub" user)
- [ ] Change UI to make email optional in "Add a team member flow" (Denote that a user will be invited to manage their own account)
- [ ] Add indicator or label on Team management UI (show that a user has signed up)
- [x] Add ability to invite a user w/ email
