### PR TITLE
Fix account deletion bug (#56)

### DIFF
--- a/app/views/Account.jsx
+++ b/app/views/Account.jsx
@@ -86,7 +86,7 @@ class Account extends React.Component {
             Change your basic account and privacy information
           </p>
 
-          <form method="post" action="/account/delete">
+          <form method="post" action="/account">
 
             <CSRFToken {...this.props} />
 


### PR DESCRIPTION
The bug was introduced by a simple typo in 2acdb7537fb75f83c304e7f0c9c7b292d074d899.

There's two form tags on the page. The first should go to `/account` and the second to `/account/delete`.

Fixes issue #56