### PR TITLE
Fix null location for owner in team

### DIFF
--- a/app/controllers/team.js
+++ b/app/controllers/team.js
@@ -31,7 +31,13 @@ team.index = function(req, res, next) {
                          'toJSON';
 
       // Ensure we're exposing the right data
-      team.people = team.people.map(function(u) { return u[toJSONMethod](); });
+      team.people = team.people.map(function(teamUser) {
+        if (teamUser.isOwnedBy(req.user) || teamUser.isOwnedBy(res.locals.impersonateUser)) {
+          return teamUser.toOwnerJSON();
+        }
+
+        return teamUser[toJSONMethod]();
+      });
 
       // Organize into timezones
       var time = moment();

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -272,6 +272,10 @@ userSchema.methods = {
     return this._id.toString() === SUPER_ADMIN_ID;
   },
 
+  isOwnedBy: function(user) {
+    return !!user && this._id.toString() === user._id.toString();
+  },
+
   isEmptyUser: function() {
     return !this.hashedPassword;
   },


### PR DESCRIPTION
When selecting the "time-only" privacy setting, the current user/owner would see `NULL` as their location in the team view. This fix ensures the current user/owner always sees their own location.

Fixes #64

### Results
Last option used to show `NULL` for owner instead of `NYC`
![fix-64](https://user-images.githubusercontent.com/250287/37250316-b72b4e3a-24c7-11e8-80de-430f4f6b8db6.png)
