### PR TITLE
Fix null as top city when a location is available

### DIFF
--- a/app/components/timezone.jsx
+++ b/app/components/timezone.jsx
@@ -16,6 +16,10 @@ module.exports = React.createClass({
       })
       .sort()
       .reduce(function(counts, el) {
+        if (el === null) {
+          return counts;
+        }
+
         if (!counts[el])
           counts[el] = 1;
         else
@@ -86,14 +90,16 @@ module.exports = React.createClass({
 
     if (this.props.timezone.major) timezoneClasses += ' timezone-major';
 
-    var topCity = this.getTopCity() || 'Add location';
+    var topCity = this.getTopCity();
+    var displayTopCity = topCity === '' ? 'Add location' : topCity || 'Hidden';
+
     var columns = this.getPeopleColumns(this.props.timezone.people);
 
     return (
       <div className={timezoneClasses}>
         <div className="timezone-header">
           <h3 className="timezone-time">{displayTime}</h3>
-          <p className="timezone-name">{topCity}</p>
+          <p className="timezone-name">{displayTopCity}</p>
           <p className="timezone-offset">{offset}</p>
         </div>
         <div className="timezone-people">


### PR DESCRIPTION
The main objective of this PR is to remove "NULL" from a timezone's top location. Instead:

- if all users of that timezone have chosen to hide their location then "Hidden" is displayed
- or if the majority of users in that timezone did not yet supply their location, then "Add Location" is displayed
- otherwise a city or timezone name is displayed ([condition in timezone.jsx](https://github.com/patrickdaze/timezoneio/blob/79c33925d78fbb01eed3d92afd68a94b4b266b5d/app/components/timezone.jsx#L46-L54))


### Example

If a timezone has the following top city counts:
`{ null: 4, NYC: 3, Ottawa: 1, Quebec: 1, Nash: 1 }`

Before the PR, "NULL" would be displayed as the timezone's top city. After the PR, "NYC" would be displayed as the timezone's top city.

(left screenshot = before / right screenshot = after)
![screen shot 2018-03-11 at 1 26 57 pm](https://user-images.githubusercontent.com/250287/37256374-2ad0faa2-2530-11e8-9175-5e73d9cc54b2.png) ![screen shot 2018-03-11 at 1 26 43 pm](https://user-images.githubusercontent.com/250287/37256375-2ec9d412-2530-11e8-920a-f0cb8168c0aa.png)

*Note: The info/time of a person is displayed in screenshot for demo purposes. In actuality they're hidden until someone hovers over.*

Fixes #65 